### PR TITLE
WIP: PlantUML and Markdown Export support

### DIFF
--- a/apkdetails.iml
+++ b/apkdetails.iml
@@ -7,7 +7,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/src/main/java/uk/co/alt236/apkdetails/ApkDetails.java
+++ b/src/main/java/uk/co/alt236/apkdetails/ApkDetails.java
@@ -1,10 +1,7 @@
 package uk.co.alt236.apkdetails;
 
 import uk.co.alt236.apkdetails.cli.CommandLineOptions;
-import uk.co.alt236.apkdetails.output.FilesOutputter;
-import uk.co.alt236.apkdetails.output.OutputPathFactory;
-import uk.co.alt236.apkdetails.output.RawTexttOutputter;
-import uk.co.alt236.apkdetails.output.StatisticsOutputter;
+import uk.co.alt236.apkdetails.output.*;
 import uk.co.alt236.apkdetails.output.loging.Logger;
 import uk.co.alt236.apkdetails.print.writer.FileWriter;
 import uk.co.alt236.apkdetails.repo.common.ZipContents;
@@ -34,6 +31,7 @@ class ApkDetails {
         final FilesOutputter filesOutputter = new FilesOutputter(fileSizeFormatter, colorizer, verbose);
         final StatisticsOutputter statsOutputter = new StatisticsOutputter(fileSizeFormatter, colorizer);
         final RawTexttOutputter rawTextOutputter = new RawTexttOutputter(fileSizeFormatter, colorizer);
+        final PlantUmlOutputter plantUmlOutputter = new PlantUmlOutputter();
 
         for (final String apkFile : files) {
             final File file = new File(apkFile);
@@ -52,6 +50,8 @@ class ApkDetails {
             }
 
             filesOutputter.doOutput(outputPathFactory, manifestRepository, dexRepository);
+
+            plantUmlOutputter.doOutput(outputPathFactory, dexRepository, cli.getPackageFilter());
 
             zipContents.close();
         }

--- a/src/main/java/uk/co/alt236/apkdetails/cli/CommandLineOptions.java
+++ b/src/main/java/uk/co/alt236/apkdetails/cli/CommandLineOptions.java
@@ -27,6 +27,10 @@ public class CommandLineOptions {
         return commandLine.getOptionValue(OptionsBuilder.ARG_INPUT_LONG);
     }
 
+    public String getPackageFilter() {
+        return commandLine.getOptionValue(OptionsBuilder.ARGS_PACKAGE_FILTER_LONG);
+    }
+
     public boolean isRecursiveApkSearch() {
         return commandLine.hasOption(OptionsBuilder.ARG_RECURSIVE_LONG);
     }

--- a/src/main/java/uk/co/alt236/apkdetails/cli/OptionsBuilder.java
+++ b/src/main/java/uk/co/alt236/apkdetails/cli/OptionsBuilder.java
@@ -26,6 +26,9 @@ public class OptionsBuilder {
     /*package*/ static final String ARG_SHOW_ONLY = "s";
     /*package*/ static final String ARG_SHOW_ONLY_LONG = "show-only";
 
+    /*package*/ static final String ARGS_PACKAGE_FILTER = "p";
+    /*package*/ static final String ARGS_PACKAGE_FILTER_LONG = "package-filter";
+
     /*package*/ static final String ARG_PRINT_CLASS_LIST = "print-class-list";
     /*package*/ static final String ARG_PRINT_CLASS_TREE = "print-class-tree";
     /*package*/ static final String ARG_PRINT_CLASS_GRAPH = "print-class-graph";
@@ -46,6 +49,7 @@ public class OptionsBuilder {
         options.addOption(createOptionRecursive());
         options.addOption(createOptionHumanReadableSizes());
         options.addOption(createShowOnly());
+        options.addOption(createPackageFilter());
 
 
         final OptionGroup optionGroup = new OptionGroup();
@@ -161,4 +165,15 @@ public class OptionsBuilder {
                 .desc(desc)
                 .build();
     }
+
+    private Option createPackageFilter() {
+        final String desc = strings.getString("cli_cmd_package_filter");
+        return Option.builder(ARGS_PACKAGE_FILTER)
+                .longOpt(ARGS_PACKAGE_FILTER_LONG)
+                .hasArg(true)
+                .required(false)
+                .desc(desc)
+                .build();
+    }
+
 }

--- a/src/main/java/uk/co/alt236/apkdetails/output/OutputPathFactory.java
+++ b/src/main/java/uk/co/alt236/apkdetails/output/OutputPathFactory.java
@@ -1,5 +1,7 @@
 package uk.co.alt236.apkdetails.output;
 
+import uk.co.alt236.apkdetails.repo.dex.model.DexClass;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
@@ -62,4 +64,29 @@ public class OutputPathFactory {
             return new File(outputFolder, apk.getName() + "_class_list.txt");
         }
     }
+
+    @Nullable
+    public File getPlantUmlFile(DexClass dexClass) {
+        if (outputFolder == null) {
+            return null;
+        } else {
+            final String path = dexClass.getPackageName().toString().replaceAll("\\.", "/") + "/";
+            final File dir = new File(outputFolder, path);
+            dir.mkdirs();
+            return new File(dir, dexClass.getSimpleName() + ".plantuml");
+        }
+    }
+
+    @Nullable
+    public File getMarkdownFile(DexClass dexClass) {
+        if (outputFolder == null) {
+            return null;
+        } else {
+            final String path = dexClass.getPackageName().toString().replaceAll("\\.", "/") + "/";
+            final File dir = new File(outputFolder, path);
+            dir.mkdirs();
+            return new File(dir, dexClass.getSimpleName() + ".md");
+        }
+    }
+
 }

--- a/src/main/java/uk/co/alt236/apkdetails/output/PlantUmlOutputter.java
+++ b/src/main/java/uk/co/alt236/apkdetails/output/PlantUmlOutputter.java
@@ -1,0 +1,324 @@
+package uk.co.alt236.apkdetails.output;
+
+import org.jf.dexlib2.dexbacked.DexBackedField;
+import org.jf.dexlib2.dexbacked.DexBackedMethod;
+import org.jf.dexlib2.iface.MethodParameter;
+import uk.co.alt236.apkdetails.output.loging.Logger;
+import uk.co.alt236.apkdetails.print.writer.FileWriter;
+import uk.co.alt236.apkdetails.repo.dex.DexRepository;
+import uk.co.alt236.apkdetails.repo.dex.model.DexClass;
+
+import java.io.File;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+public class PlantUmlOutputter {
+
+    public void doOutput(OutputPathFactory outputPathFactory,
+                         DexRepository dexRepository,
+                         String packagePrefix) {
+
+        final Collection<DexClass> filteredClasses = getFilteredClasses(dexRepository, packagePrefix);
+
+        int countProcessed = 0;
+        int countSkipped = 0;
+        for (DexClass dexClass : filteredClasses) {
+            if (isClassEligible(dexClass)) {
+                processClass(outputPathFactory, dexClass);
+                countProcessed++;
+            } else {
+                countSkipped++;
+            }
+        }
+        Logger.get().out(String.format("Processed %d and skipped %d classes.", countProcessed, countSkipped));
+    }
+
+    private boolean isClassEligible(DexClass dexClass) {
+        if (dexClass.getSimpleName().endsWith("_Factory")) {
+            return false;
+        } else if (dexClass.getSimpleName().startsWith("R$")) {
+            return false;
+        } else if (dexClass.getSimpleName().endsWith("_MembersInjector")) {
+            return false;
+        } else if (dexClass.getSimpleName().contains("_Impl$")) {
+            return false;
+        } else if (dexClass.getSimpleName().endsWith("_ViewBinding")) {
+            return false;
+        } else if (dexClass.isLambda()) {
+            return false;
+        } else if (dexClass.getSimpleName().endsWith("$WhenMappings")) {
+            return false;
+        } else if (dexClass.getSimpleName().endsWith("$1")) {
+            return false;
+        } else if (dexClass.getSimpleName().startsWith("-$$")) {
+            return false;
+        } else if (dexClass.getSimpleName().startsWith("R.")) {
+            return false;
+        } else if (dexClass.getSimpleName().startsWith("BuildConfig")) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private void processClass(OutputPathFactory outputPathFactory, final DexClass dexClass) {
+
+        final StringBuilder sb = new StringBuilder();
+        final StringBuilder mb = new StringBuilder();
+
+        mb.append("# ").append(dexClass.getSimpleName()).append("\n");
+
+        sb.append("@startuml");
+        sb.append("\n");
+        sb.append("\t")
+                .append(getClassModifier(dexClass))
+                .append(" ")
+                .append(dexClass.getPackageName().toString())
+                .append(".")
+                .append(dexClass.getSimpleName())
+                .append(" {");
+
+        final StringBuilder fieldEntry = new StringBuilder();
+
+        List<DexBackedField> fields = new ArrayList<>();
+
+
+        dexClass.getDexBackedClassDef().getFields().forEach((Consumer<DexBackedField>) dexBackedField -> {
+            if (!Modifier.isVolatile(dexBackedField.accessFlags)
+                    && !dexBackedField.getName().startsWith("_")
+                    && !dexBackedField.getName().startsWith("<")) {
+                fields.add(dexBackedField);
+            }
+        });
+        fields.sort(Comparator.comparingInt(DexBackedField::getAccessFlags));
+
+        fields.forEach(dexBackedField -> {
+            sb.append("\n\t\t")
+                    .append(getStaticPrefix(dexBackedField.accessFlags))
+                    .append(getVisibilityPrefix(dexBackedField.accessFlags))
+                    .append(" ")
+                    .append(dexBackedField.getName())
+                    .append(" : ")
+                    .append(getSanitisedFieldType(dexBackedField.getType()));
+
+            fieldEntry.append("+ ")
+                    .append(getMarkdownStaticPrefix(dexBackedField.accessFlags))
+                    .append("**")
+                    .append(dexBackedField.getName())
+                    .append("**")
+                    .append(" : ")
+                    .append(getSanitisedFieldType(dexBackedField.getType()))
+                    .append("  \n");
+        });
+
+        mb.append("## Fields")
+                .append("\n")
+                .append(fieldEntry.toString().trim())
+                .append("\n");
+
+
+        mb.append("## Methods")
+                .append("\n");
+
+        sb.append("\n");
+
+        List<DexBackedMethod> methods = new ArrayList<>();
+        dexClass.getDexBackedClassDef().getMethods().forEach((Consumer<DexBackedMethod>) dexBackedMethod ->
+                {
+                    if (!Modifier.isVolatile(dexBackedMethod.accessFlags)
+                            && !dexBackedMethod.getName().startsWith("<")
+                            && !dexBackedMethod.getName().startsWith("_")
+                            && !dexBackedMethod.getName().startsWith("lambda"))
+                        methods.add(dexBackedMethod);
+                }
+        );
+        methods.sort(Comparator.comparingInt(dexBackedMethod2 -> dexBackedMethod2.accessFlags));
+
+
+        methods.forEach(dexBackedMethod -> {
+            sb.append("\n\t\t")
+                    .append(getStaticPrefix(dexBackedMethod.accessFlags))
+                    .append(getVisibilityPrefix(dexBackedMethod.accessFlags))
+                    .append(" ")
+                    .append(dexBackedMethod.getName())
+                    .append("()");
+
+            mb.append("\n\n")
+                    .append("**")
+                    .append(getMarkdownVisibilityPrefix(dexBackedMethod.accessFlags))
+                    .append(getMarkdownStaticPrefix(dexBackedMethod.accessFlags))
+                    .append(dexBackedMethod.getName())
+                    .append("()")
+                    .append("**  ")
+                    .append("\n")
+                    .append("* **Input**  ");
+
+            if (dexBackedMethod.getParameters().isEmpty()) {
+                mb.append("\n   - N/A  ");
+            } else {
+                dexBackedMethod.getParameters().forEach((Consumer<MethodParameter>) methodParameter -> mb
+                        .append("\n   - ")
+                        .append(methodParameter.getName())
+                        .append(" : ")
+                        .append(getSanitisedFieldType(methodParameter.getType()))
+                        .append("  "));
+            }
+
+            mb.append("\n")
+                    .append("* **Output**  \n   - ")
+                    .append(getSanitisedFieldType(dexBackedMethod.getReturnType()))
+                    .append("  ");
+
+        });
+        sb.append("\n\t}");
+        sb.append("\n@enduml");
+
+
+        //Logger.get().out(sb.toString());
+        //Logger.get().out(mb.toString());
+
+        final File plantUmlFile = outputPathFactory.getPlantUmlFile(dexClass);
+        FileWriter plantUmlWriter = new FileWriter(plantUmlFile);
+        plantUmlWriter.outln(sb.toString());
+        plantUmlWriter.close();
+
+        final File markdownFile = outputPathFactory.getMarkdownFile(dexClass);
+        FileWriter markdownWriter = new FileWriter(markdownFile);
+        markdownWriter.outln(mb.toString());
+        markdownWriter.close();
+
+
+    }
+
+    private String getClassModifier(DexClass dexClass) {
+        final String prefix;
+        if (Objects.equals(dexClass.getDexBackedClassDef().getSuperclass(), "Ljava/lang/Enum;")) {
+            prefix = "enum";
+        } else if (Modifier.isInterface(dexClass.getDexBackedClassDef().getAccessFlags())) {
+            prefix = "interface";
+        } else if (Modifier.isAbstract(dexClass.getDexBackedClassDef().getAccessFlags())) {
+            prefix = "abstract class";
+        } else {
+            prefix = "class";
+        }
+        return prefix;
+    }
+
+    private String getStaticPrefix(int accessFlags) {
+        final String prefix;
+        if (Modifier.isStatic(accessFlags)) {
+            prefix = "{static} ";
+        } else if (Modifier.isAbstract(accessFlags)) {
+            prefix = "{abstract} ";
+        } else {
+            prefix = "";
+        }
+        return prefix;
+    }
+
+    private String getMarkdownStaticPrefix(int accessFlags) {
+        final String prefix;
+        if (Modifier.isStatic(accessFlags)) {
+            prefix = "static ";
+        } else if (Modifier.isInterface(accessFlags)) {
+            prefix = "interface ";
+        } else if (Modifier.isAbstract(accessFlags)) {
+            prefix = "abstract ";
+        } else {
+            prefix = "";
+        }
+        return prefix;
+    }
+
+    private String getVisibilityPrefix(int accessFlags) {
+        String visibilityPrefix;
+        if (Modifier.isPublic(accessFlags)) {
+            visibilityPrefix = "+";
+        } else if (Modifier.isProtected(accessFlags)) {
+            visibilityPrefix = "#";
+        } else if (Modifier.isPrivate(accessFlags)) {
+            visibilityPrefix = "-";
+        } else {
+            visibilityPrefix = "#";
+        }
+        return visibilityPrefix;
+    }
+
+    private String getMarkdownVisibilityPrefix(int accessFlags) {
+        String visibilityPrefix;
+        if (Modifier.isPublic(accessFlags)) {
+            visibilityPrefix = "public ";
+        } else if (Modifier.isProtected(accessFlags)) {
+            visibilityPrefix = "protected ";
+        } else if (Modifier.isPrivate(accessFlags)) {
+            visibilityPrefix = "private ";
+        } else {
+            visibilityPrefix = "";
+        }
+        return visibilityPrefix;
+    }
+
+    private String getSanitisedFieldType(String type) {
+        final String sanitisedType;
+        if (type.contains("/")) {
+            String[] parts = type.split(Pattern.quote("/"));
+            String finalPart = parts[parts.length - 1];
+            sanitisedType = finalPart.replaceAll(";", "");
+        } else {
+            switch (type) {
+                case "V":
+                    sanitisedType = "Void";
+                    break;
+                case "B":
+                    sanitisedType = "Byte";
+                    break;
+                case "S":
+                    sanitisedType = "Short";
+                    break;
+                case "C":
+                    sanitisedType = "Character";
+                    break;
+                case "I":
+                    sanitisedType = "Integer";
+                    break;
+                case "J":
+                    sanitisedType = "Long";
+                    break;
+                case "F":
+                    sanitisedType = "Float";
+                    break;
+                case "D":
+                    sanitisedType = "Double";
+                    break;
+                case "Z":
+                    sanitisedType = "Boolean";
+                    break;
+                default:
+                    // fallback
+                    sanitisedType = type;
+                    break;
+            }
+        }
+        return sanitisedType;
+    }
+
+    private Collection<DexClass> getFilteredClasses(final DexRepository dexRepository,
+                                                    final String packagePrefix) {
+        final Collection<DexClass> classes = dexRepository.getAllClasses();
+
+        Logger.get().out(String.format("Total Classes size: %d", classes.size()));
+        final Collection<DexClass> filteredClasses = new ArrayList<>();
+        classes.forEach(dexClass -> {
+            final String packageName = dexClass.getPackageName().toString();
+            if (packageName.startsWith(packagePrefix) && !dexClass.isLambda()) {
+                filteredClasses.add(dexClass);
+            }
+        });
+        Logger.get().out(String.format("Filtered Classes size: %d", filteredClasses.size()));
+
+        return filteredClasses;
+    }
+
+}

--- a/src/main/java/uk/co/alt236/apkdetails/repo/dex/model/DexClass.java
+++ b/src/main/java/uk/co/alt236/apkdetails/repo/dex/model/DexClass.java
@@ -15,10 +15,14 @@ public class DexClass {
     private final String type;
     private final String superType;
     private final PackageName packageName;
+    private final Class javaClass;
+    private final DexBackedClassDef dexBackedClassDef;
 
     private DexClass(final String dexFileName, final DexBackedClassDef classDef) {
         final DexClassInfo dexClassInfo = new DexClassInfo();
+        this.javaClass = classDef.getClass();
         this.dexFileName = dexFileName;
+        this.dexBackedClassDef = classDef;
         this.name = dexClassInfo.getClassSimpleName(classDef);
         this.type = classDef.getType();
         this.superType = classDef.getSuperclass();
@@ -64,5 +68,13 @@ public class DexClass {
 
     public String getDexFileName() {
         return dexFileName;
+    }
+
+    public Class getJavaClass() {
+        return javaClass;
+    }
+
+    public DexBackedClassDef getDexBackedClassDef() {
+        return dexBackedClassDef;
     }
 }

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: uk.co.alt236.apkdetails.Main
+

--- a/src/main/resources/strings.properties
+++ b/src/main/resources/strings.properties
@@ -10,3 +10,4 @@ cli_cmd_print_class_list=Print the APK classes as a list to the terminal. It ign
 cli_cmd_print_class_tree=Print the APK classes as an ASCII tree to terminal. It ignores all options except -i and -o.
 cli_cmd_print_class_graph=Print the APK classes as a GraphML graph to terminal. It ignores all options except -i and -o.
 cli_cmd_print_manifest=Print the APK manifest to the terminal. It ignores all options except -i and -o.
+cli_cmd_package_filter=If set, filters classes by selected package prefix.


### PR DESCRIPTION
Massive WIP!!!

This is written as quickly and hardcoded as possible. Will get around to fixing it soooooooooon (famous last words).

### Changes

- 2 new export types are supported: To PlantUML and to Markdown. A file will be generated for each class.

### New CLI Parameters

- Added a `-p [package_prefix]` parameter for filtering a DexClass list by package name.
- No parameters added for toggling the 2 new exports (yet!).

### Sample Usage
-h --input /some.apk -p com.alt234 -o /output/